### PR TITLE
fix: quick launcher hover text color for dark themes

### DIFF
--- a/scripts/create_theme.py
+++ b/scripts/create_theme.py
@@ -36,7 +36,7 @@ def create_theme(types: List[str], accents: List[str], dest: str = tmp_dir, link
             try:
                 # Rename colloid generated files as per catppuccin
                 new_filename = dest + \
-                    f"/{theme_name}-{type.capitalize()}-{size.capitalize()}-{accent.capitalize()}"
+                    f"/{theme_name}-{type.capitalize()}-{size.capitalize()}-{accent.capitalize()}-{theme_style.title()}"
                 filename = f"{theme_name}"
                 if def_color_map[accent] != 'default':
                     filename += f"-{def_color_map[accent].capitalize()}"


### PR DESCRIPTION
Dark themes are supposed to have a `-Dark` suffix to their names. Adding the suffix fixes the weird text color issue in PopOS quick launcher after applying this theme.

Note: This changes the release zip file names

Before
![image](https://user-images.githubusercontent.com/10350864/206934682-f81aebd6-2dae-48f1-ab49-f9502a798717.png)

 
After
![image](https://user-images.githubusercontent.com/10350864/206934593-a032894c-ad4c-4f23-a75c-95879e9ffbb9.png)

Environment
- gtk 3.24.33
- PoP_OS 22.04 LTS 