### PR TITLE
Use correct for `theme_style` case in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To use it in home-manager:
   gtk = {
     enable = true;
     theme = {
-      name = "Catppuccin-Macchiato-Compact-Pink-Dark";
+      name = "Catppuccin-Macchiato-Compact-Pink-dark";
       package = pkgs.catppuccin-gtk.override {
         accents = [ "pink" ];
         size = "compact";


### PR DESCRIPTION
Fixes #99

Since this update the theme-style is not capitalized anymore.
https://github.com/catppuccin/gtk/commit/3fc72208deec4b7f8c22a2c77a21fde341e29cb6

This updates the Readme to match