### PR TITLE
Revert "fix theme name in readme"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To use it in home-manager:
   gtk = {
     enable = true;
     theme = {
-      name = "Catppuccin-Macchiato-Compact-Pink-dark";
+      name = "Catppuccin-Macchiato-Compact-Pink-Dark";
       package = pkgs.catppuccin-gtk.override {
         accents = [ "pink" ];
         size = "compact";


### PR DESCRIPTION
f13a2b2 changed the naming convention for the theme names again so that the theme style (dark or light) is capitalized again. The docs were updated accordingly for Home Manager.

However, eb7ed7a changed the docs for Home Manager back to the non-capitalized names. This was likely because the capitalization change had not made its way to `nixos-unstable`. The change has now made it to `nixos-unstable`, so eb7ed7a has been reverted to reflect the capitalization.