### PR TITLE
fix(status_bar): correctly apply latte colours

### DIFF
--- a/scripts/recolor.py
+++ b/scripts/recolor.py
@@ -124,7 +124,7 @@ def recolor(flavor, accent: str):
     print("Mod SASS Color_Palette_default")
 
     # Greys
-    if flavor.name == PALETTE.latte.name:  # Hardcode till someone smarter than me comes along
+    if flavor.name == PALETTE.latte.name:
         replacetext(f"{src_dir}/sass/_color-palette-default.scss",
                     "grey-050: #FAFAFA", f"grey-050: {colors.crust.hex}")
         replacetext(f"{src_dir}/sass/_color-palette-default.scss",

--- a/scripts/recolor.py
+++ b/scripts/recolor.py
@@ -86,7 +86,7 @@ def recolor(flavor, accent: str):
     replacetext(f"{work_dir}/gtkrc.sh",
                 "titlebar_light='#F2F2F2'", f"titlebar_light='{latte_colors.crust.hex}'")
 
-    if flavor.name == "latte":
+    if flavor.name == PALETTE.latte.name:
         replacetext(f"{work_dir}/gtkrc.sh", "background_dark='#0F0F0F'",
                     f"background_dark='{mocha_colors.base.hex}'")
         replacetext(f"{work_dir}/gtkrc.sh", "background_darker='#121212'",
@@ -124,7 +124,7 @@ def recolor(flavor, accent: str):
     print("Mod SASS Color_Palette_default")
 
     # Greys
-    if flavor.name == "latte":  # Hardcode till someone smarter than me comes along
+    if flavor.name == PALETTE.latte.name:  # Hardcode till someone smarter than me comes along
         replacetext(f"{src_dir}/sass/_color-palette-default.scss",
                     "grey-050: #FAFAFA", f"grey-050: {colors.crust.hex}")
         replacetext(f"{src_dir}/sass/_color-palette-default.scss",


### PR DESCRIPTION
The change you've made in https://github.com/catppuccin/gtk/commit/355e12387f73b27cf4734a6a3eb431554fabb74f has a small bug relate to the flavor name hardcode part. I believe the key that you want to compare to the hard code string is `identifier` instead of `name` (https://github.com/catppuccin/python/blob/main/catppuccin/palette.py), however imo, we shouldn't hardcode it, so I make a simple change there.

This commit will fix some pallete mismatch on current `latte` variant.
Before:
![Screenshot from 2024-04-08 10-41-40](https://github.com/catppuccin/gtk/assets/47441476/7d194af4-21f8-4b66-bed8-1f40ecd7e1b1)
After:
![Screenshot from 2024-04-08 10-44-54](https://github.com/catppuccin/gtk/assets/47441476/691aa347-4c81-407c-82d6-8516291d77c4)
