### PR TITLE
fix: argument `--accent` behaves like the old argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
         run: sudo apt update && sudo apt install -y sassc inkscape optipng
       - name: Generate themes
         run: |
-          python ./build.py mocha -a all --zip -d $PWD/releases &&
-          python ./build.py macchiato -a all --zip -d $PWD/releases &&
-          python ./build.py frappe -a all --zip -d $PWD/releases &&
-          python ./build.py latte -a all --zip -d $PWD/releases
+          python ./build.py mocha --all-accents --zip -d $PWD/releases &&
+          python ./build.py macchiato --all-accents --zip -d $PWD/releases &&
+          python ./build.py frappe --all-accents --zip -d $PWD/releases &&
+          python ./build.py latte --all-accents --zip -d $PWD/releases
       - name: Add zips to release
         uses: softprops/action-gh-release@v2
         with:

--- a/build.py
+++ b/build.py
@@ -542,9 +542,15 @@ def parse_args():
             "sapphire",
             "blue",
             "lavender",
-            "all",
         ],
         help="Accent of the theme.",
+    )
+
+    parser.add_argument(
+        "--all-accents",
+        help="Whether to build all accents",
+        dest="all_accents",
+        action="store_true",
     )
 
     parser.add_argument(
@@ -601,7 +607,7 @@ def main():
     palette = getattr(PALETTE, args.flavor)
 
     accents = args.accents
-    if "all" in accents:
+    if args.all_accents:
         accents = [
             "rosewater",
             "flamingo",

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 import os, re, shutil, subprocess, argparse, glob, logging, zipfile
 
 from dataclasses import dataclass
@@ -525,7 +525,8 @@ def parse_args():
         "-a",
         type=str,
         default="mauve",
-        dest="accent",
+        nargs='+',
+        dest="accents",
         choices=[
             "rosewater",
             "flamingo",
@@ -598,44 +599,35 @@ def main():
     tweaks = Tweaks(tweaks=args.tweaks)
 
     palette = getattr(PALETTE, args.flavor)
-    accents = [
-        "rosewater",
-        "flamingo",
-        "pink",
-        "mauve",
-        "red",
-        "maroon",
-        "peach",
-        "yellow",
-        "green",
-        "teal",
-        "sky",
-        "sapphire",
-        "blue",
-        "lavender",
-    ]
 
-    if args.accent == "all":
-        for accent in accents:
-            accent = getattr(palette.colors, accent)
+    accents = args.accents
+    if "all" in accents:
+        accents = [
+            "rosewater",
+            "flamingo",
+            "pink",
+            "mauve",
+            "red",
+            "maroon",
+            "peach",
+            "yellow",
+            "green",
+            "teal",
+            "sky",
+            "sapphire",
+            "blue",
+            "lavender",
+        ]
 
-            ctx = BuildContext(
-                build_root=args.dest,
-                theme_name=args.name,
-                flavor=palette,
-                accent=accent,
-                size=args.size,
-                tweaks=tweaks,
-                output_format=output_format,
-            )
+    for accent in accents:
+        accent = getattr(palette.colors, accent)
 
-            tweaks_temp()
-            gnome_shell_version()
-            build_theme(ctx)
-            logger.info("Done!")
-    else:
-        accent = getattr(palette.colors, args.accent)
+        tweaks = Tweaks(tweaks=args.tweaks)
 
+        if args.zip:
+            output_format = "zip"
+        else:
+            output_format = "dir"
         ctx = BuildContext(
             build_root=args.dest,
             theme_name=args.name,
@@ -645,7 +637,6 @@ def main():
             tweaks=tweaks,
             output_format=output_format,
         )
-
         logger.info("Building temp tweaks file")
         tweaks_temp()
         logger.info("Inserting gnome-shell imports")
@@ -653,7 +644,6 @@ def main():
         logger.info("Building main theme")
         build_theme(ctx)
         logger.info("Done!")
-
 
 try:
     main()

--- a/build.py
+++ b/build.py
@@ -649,7 +649,9 @@ def main():
         gnome_shell_version()
         logger.info("Building main theme")
         build_theme(ctx)
-        logger.info("Done!")
+        logger.info(f"Completed {palette.identifier} with {accent.identifier}")
+
+    logger.info("Done!")
 
 try:
     main()


### PR DESCRIPTION
tested with the following commands
- `python3 build.py mocha -a rosewater all --dest ./dist`
- `python3 build.py mocha -a rosewater sapphire --dest ./dist`
- `python3 build.py mocha -a sapphire --dest ./dist`