### PR TITLE
ci: exit with non zero exit code when a build fails

### DIFF
--- a/build.py
+++ b/build.py
@@ -73,8 +73,6 @@ def build(ctx: BuildContext):
 
     apply_tweaks(ctx)
 
-    raise TypeError('This should fail the build')
-
     os.makedirs(output_dir, exist_ok=True)
     with open(f"{output_dir}/index.theme", "w") as file:
         file.write("[Desktop Entry]\n")


### PR DESCRIPTION
Closes #230 