### PR TITLE
fix: allow all accents to be used

### DIFF
--- a/build.py
+++ b/build.py
@@ -231,38 +231,13 @@ def gnome_shell_version():
             f"@import 'extensions-{GS_VERSION}';",
         )
 
-
-# Accent translation
-ctp_to_colloid = {
-    "rosewater": "pink",
-    "flamingo": "pink",
-    "pink": "pink",
-    "mauve": "purple",
-    "red": "red",
-    "maroon": "red",
-    "peach": "orange",
-    "yellow": "yellow",
-    "green": "green",
-    "teal": "teal",
-    "sky": "teal",
-    "sapphire": "default",
-    "blue": "default",
-    "lavender": "default",
-}
-
-
-def translate_accent(ctp_accent: Color):
-    return ctp_to_colloid[ctp_accent.identifier]
-
-
 def write_tweak(key, default, value):
     subst_text(
         f"{SRC_DIR}/sass/_tweaks-temp.scss", f"\\${key}: {default}", f"${key}: {value}"
     )
 
-
 def apply_tweaks(ctx: BuildContext):
-    write_tweak("theme", "'default'", f"'{translate_accent(ctx.accent)}'")
+    write_tweak("theme", "'default'", f"'{ctx.accent.identifier}'")
 
     if ctx.size == "compact":
         write_tweak("compact", "'false'", "'true'")
@@ -476,6 +451,7 @@ def apply_colloid_patches():
     for patch in [
         "plank-dark.patch",
         "plank-light.patch",
+        "theme-func.patch",
         "sass-palette-frappe.patch",
         "sass-palette-mocha.patch",
         "sass-palette-latte.patch",

--- a/patches/colloid/palette.tera
+++ b/patches/colloid/palette.tera
@@ -11,7 +11,22 @@ new file mode 100644
 index 00000000..4ff0da0d
 --- /dev/null
 +++ b/src/sass/_color-palette-catppuccin-{{ flavor.identifier }}.scss
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,87 @@
++ // Our accents
++ $rosewater: #{{ palette.rosewater.hex }};
++ $flamingo: #{{ palette.flamingo.hex }};
++ $pink: #{{ palette.pink.hex }};
++ $mauve: #{{ palette.mauve.hex }};
++ $red: #{{ palette.red.hex }};
++ $maroon: #{{ palette.maroon.hex }};
++ $peach: #{{ palette.peach.hex }};
++ $yellow: #{{ palette.yellow.hex }};
++ $green: #{{ palette.green.hex }};
++ $teal: #{{ palette.teal.hex }};
++ $sky: #{{ palette.sky.hex }};
++ $sapphire: #{{ palette.sapphire.hex }};
++ $blue: #{{ palette.blue.hex }};
++ $lavender: #{{ palette.lavender.hex }};
 +// Default Theme Color Palette
 +
 +// Red

--- a/patches/colloid/sass-palette-frappe.patch
+++ b/patches/colloid/sass-palette-frappe.patch
@@ -3,7 +3,22 @@ new file mode 100644
 index 00000000..4ff0da0d
 --- /dev/null
 +++ b/src/sass/_color-palette-catppuccin-frappe.scss
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,87 @@
++ // Our accents
++ $rosewater: #f2d5cf;
++ $flamingo: #eebebe;
++ $pink: #f4b8e4;
++ $mauve: #ca9ee6;
++ $red: #e78284;
++ $maroon: #ea999c;
++ $peach: #ef9f76;
++ $yellow: #e5c890;
++ $green: #a6d189;
++ $teal: #81c8be;
++ $sky: #99d1db;
++ $sapphire: #85c1dc;
++ $blue: #8caaee;
++ $lavender: #babbf1;
 +// Default Theme Color Palette
 +
 +// Red

--- a/patches/colloid/sass-palette-latte.patch
+++ b/patches/colloid/sass-palette-latte.patch
@@ -3,7 +3,22 @@ new file mode 100644
 index 00000000..4ff0da0d
 --- /dev/null
 +++ b/src/sass/_color-palette-catppuccin-latte.scss
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,87 @@
++ // Our accents
++ $rosewater: #dc8a78;
++ $flamingo: #dd7878;
++ $pink: #ea76cb;
++ $mauve: #8839ef;
++ $red: #d20f39;
++ $maroon: #e64553;
++ $peach: #fe640b;
++ $yellow: #df8e1d;
++ $green: #40a02b;
++ $teal: #179299;
++ $sky: #04a5e5;
++ $sapphire: #209fb5;
++ $blue: #1e66f5;
++ $lavender: #7287fd;
 +// Default Theme Color Palette
 +
 +// Red

--- a/patches/colloid/sass-palette-macchiato.patch
+++ b/patches/colloid/sass-palette-macchiato.patch
@@ -3,7 +3,22 @@ new file mode 100644
 index 00000000..4ff0da0d
 --- /dev/null
 +++ b/src/sass/_color-palette-catppuccin-macchiato.scss
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,87 @@
++ // Our accents
++ $rosewater: #f4dbd6;
++ $flamingo: #f0c6c6;
++ $pink: #f5bde6;
++ $mauve: #c6a0f6;
++ $red: #ed8796;
++ $maroon: #ee99a0;
++ $peach: #f5a97f;
++ $yellow: #eed49f;
++ $green: #a6da95;
++ $teal: #8bd5ca;
++ $sky: #91d7e3;
++ $sapphire: #7dc4e4;
++ $blue: #8aadf4;
++ $lavender: #b7bdf8;
 +// Default Theme Color Palette
 +
 +// Red

--- a/patches/colloid/sass-palette-mocha.patch
+++ b/patches/colloid/sass-palette-mocha.patch
@@ -3,7 +3,22 @@ new file mode 100644
 index 00000000..4ff0da0d
 --- /dev/null
 +++ b/src/sass/_color-palette-catppuccin-mocha.scss
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,87 @@
++ // Our accents
++ $rosewater: #f5e0dc;
++ $flamingo: #f2cdcd;
++ $pink: #f5c2e7;
++ $mauve: #cba6f7;
++ $red: #f38ba8;
++ $maroon: #eba0ac;
++ $peach: #fab387;
++ $yellow: #f9e2af;
++ $green: #a6e3a1;
++ $teal: #94e2d5;
++ $sky: #89dceb;
++ $sapphire: #74c7ec;
++ $blue: #89b4fa;
++ $lavender: #b4befe;
 +// Default Theme Color Palette
 +
 +// Red

--- a/patches/colloid/theme-func.patch
+++ b/patches/colloid/theme-func.patch
@@ -1,0 +1,46 @@
+diff --git a/src/sass/_colors.scss b/src/sass/_colors.scss
+index 8738bf37..71797c6d 100644
+--- a/src/sass/_colors.scss
++++ b/src/sass/_colors.scss
+@@ -58,27 +58,20 @@
+ }
+ 
+ @function theme($color) {
+-  @if ($variant == 'light') {
+-    @if ($theme == 'default') { @return $default-dark; }
+-    @if ($theme == 'purple') { @return $purple-dark; }
+-    @if ($theme == 'pink') { @return $pink-dark; }
+-    @if ($theme == 'red') { @return $red-dark; }
+-    @if ($theme == 'orange') { @return $orange-dark; }
+-    @if ($theme == 'yellow') { @return $yellow-dark; }
+-    @if ($theme == 'green') { @return $green-dark; }
+-    @if ($theme == 'teal') { @return $teal-dark; }
+-    @if ($theme == 'grey') { @return $grey-600; }
+-  } @else {
+-    @if ($theme == 'default') { @return $default-light; }
+-    @if ($theme == 'purple') { @return $purple-light; }
+-    @if ($theme == 'pink') { @return $pink-light; }
+-    @if ($theme == 'red') { @return $red-light; }
+-    @if ($theme == 'orange') { @return $orange-light; }
+-    @if ($theme == 'yellow') { @return $yellow-light; }
+-    @if ($theme == 'green') { @return $green-light; }
+-    @if ($theme == 'teal') { @return $teal-light; }
+-    @if ($theme == 'grey') { @return $grey-200; }
+-  }
++  @if ($theme == 'rosewater') { @return $rosewater; }
++  @if ($theme == 'flamingo') { @return $flamingo; }
++  @if ($theme == 'pink') { @return $pink; }
++  @if ($theme == 'mauve') { @return $mauve; }
++  @if ($theme == 'red') { @return $red; }
++  @if ($theme == 'maroon') { @return $maroon; }
++  @if ($theme == 'peach') { @return $peach; }
++  @if ($theme == 'yellow') { @return $yellow; }
++  @if ($theme == 'green') { @return $green; }
++  @if ($theme == 'teal') { @return $teal; }
++  @if ($theme == 'sky') { @return $sky; }
++  @if ($theme == 'sapphire') { @return $sapphire; }
++  @if ($theme == 'blue') { @return $blue; }
++  @if ($theme == 'lavender') { @return $lavender; }
+ }
+ 
+ @function background($type) {


### PR DESCRIPTION
This allows all the accents to be used properly, and fixes a regression that disallowed this. The regression was caused by a misunderstanding in the old build system (lol).

We achieve this by patching out the `@theme` function from colloid, and replacing it with our own, and including all of the accents in our palette css. It is not the most robust solution, as if colloid changes this file our patch will need adjusting, but I think it's better than going scatterbomb find-and-replace on all of colloid without any safety mechanisms :+1: .