### PR TITLE
fix: trying to make theme work universally

### DIFF
--- a/build.py
+++ b/build.py
@@ -43,7 +43,6 @@ IS_WINDOW_NORMAL = Suffix(true_value="-Normal", test=lambda ctx: ctx.tweaks.has(
 DARK_LIGHT = Suffix(
     true_value="-Dark", false_value="-Light", test=lambda ctx: ctx.flavor.dark
 )
-GTK_SUFFIX = Suffix(true_value='-Dark', false_value='-Light', test=lambda ctx: ctx.flavor.dark)
 
 @dataclass
 class BuildContext:
@@ -56,7 +55,7 @@ class BuildContext:
     tweaks: Tweaks
 
     def output_dir(self) -> str:
-        return f"{self.build_root}/{self.build_id()}{self.apply_suffix(GTK_SUFFIX)}"
+        return f"{self.build_root}/{self.build_id()}"
 
     def build_id(self) -> str:
         return f"{self.theme_name}-{self.flavor.identifier}-{self.accent.identifier}-{self.size}+{self.tweaks.id() or 'default'}"
@@ -78,13 +77,13 @@ def build(ctx: BuildContext):
     with open(f"{output_dir}/index.theme", "w") as file:
         file.write("[Desktop Entry]\n")
         file.write("Type=X-GNOME-Metatheme\n")
-        file.write(f"Name={ctx.build_id()}{ctx.apply_suffix(GTK_SUFFIX)}\n")
+        file.write(f"Name={ctx.build_id()}\n")
         file.write("Comment=An Flat Gtk+ theme based on Elegant Design\n")
         file.write("Encoding=UTF-8\n")
         file.write("\n")
         file.write("[X-GNOME-Metatheme]\n")
-        file.write(f"GtkTheme={ctx.build_id()}{ctx.apply_suffix(GTK_SUFFIX)}\n")
-        file.write(f"MetacityTheme={ctx.build_id()}{ctx.apply_suffix(GTK_SUFFIX)}\n")
+        file.write(f"GtkTheme={ctx.build_id()}\n")
+        file.write(f"MetacityTheme={ctx.build_id()}\n")
         file.write(f"IconTheme=Tela-circle{ctx.apply_suffix(IS_DARK)}\n")
         file.write(f"CursorTheme={ctx.flavor.name}-cursors\n")
         file.write("ButtonLayout=close,minimize,maximize:menu\n")
@@ -116,8 +115,7 @@ def build(ctx: BuildContext):
         [
             "sassc",
             *SASSC_OPT,
-            # NOTE: This uses 'Dark' for the source, but 'dark' for the destination. This is intentional. Do !!NOT!! change it without consultation
-            f"{SRC_DIR}/main/gtk-3.0/gtk-Dark.scss",
+            f"{SRC_DIR}/main/gtk-3.0/gtk{ctx.apply_suffix(DARK_LIGHT)}.scss",
             f"{output_dir}/gtk-3.0/gtk-dark.css",
         ]
     )
@@ -135,8 +133,7 @@ def build(ctx: BuildContext):
         [
             "sassc",
             *SASSC_OPT,
-            # NOTE: This uses 'Dark' for the source, but 'dark' for the destination. This is intentional. Do !!NOT!! change it without consultation
-            f"{SRC_DIR}/main/gtk-4.0/gtk-Dark.scss",
+            f"{SRC_DIR}/main/gtk-4.0/gtk{ctx.apply_suffix(DARK_LIGHT)}.scss",
             f"{output_dir}/gtk-4.0/gtk-dark.css",
         ]
     )

--- a/build.py
+++ b/build.py
@@ -43,6 +43,7 @@ IS_WINDOW_NORMAL = Suffix(true_value="-Normal", test=lambda ctx: ctx.tweaks.has(
 DARK_LIGHT = Suffix(
     true_value="-Dark", false_value="-Light", test=lambda ctx: ctx.flavor.dark
 )
+GTK_SUFFIX = Suffix(true_value='-Dark', false_value='-Light', test=lambda ctx: ctx.flavor.dark)
 
 @dataclass
 class BuildContext:
@@ -55,10 +56,7 @@ class BuildContext:
     tweaks: Tweaks
 
     def output_dir(self) -> str:
-        suffix = "light"
-        if self.flavor.dark:
-            suffix = "dark"
-        return f"{self.build_root}/{self.build_id()}-{suffix}"
+        return f"{self.build_root}/{self.build_id()}{self.apply_suffix(GTK_SUFFIX)}"
 
     def build_id(self) -> str:
         return f"{self.theme_name}-{self.flavor.identifier}-{self.accent.identifier}-{self.size}+{self.tweaks.id() or 'default'}"
@@ -80,13 +78,13 @@ def build(ctx: BuildContext):
     with open(f"{output_dir}/index.theme", "w") as file:
         file.write("[Desktop Entry]\n")
         file.write("Type=X-GNOME-Metatheme\n")
-        file.write(f"Name={ctx.build_id()}\n")
+        file.write(f"Name={ctx.build_id()}{ctx.apply_suffix(GTK_SUFFIX)}\n")
         file.write("Comment=An Flat Gtk+ theme based on Elegant Design\n")
         file.write("Encoding=UTF-8\n")
         file.write("\n")
         file.write("[X-GNOME-Metatheme]\n")
-        file.write(f"GtkTheme={ctx.build_id()}\n")
-        file.write(f"MetacityTheme={ctx.build_id()}\n")
+        file.write(f"GtkTheme={ctx.build_id()}{ctx.apply_suffix(GTK_SUFFIX)}\n")
+        file.write(f"MetacityTheme={ctx.build_id()}{ctx.apply_suffix(GTK_SUFFIX)}\n")
         file.write(f"IconTheme=Tela-circle{ctx.apply_suffix(IS_DARK)}\n")
         file.write(f"CursorTheme={ctx.flavor.name}-cursors\n")
         file.write("ButtonLayout=close,minimize,maximize:menu\n")


### PR DESCRIPTION
Might close #258 

Honestly at this point I don't even know what's happening.

GTK3 doesn't like it when you use `-dark` on dark themes, you must use `-Dark` for it to apply properly. 
This does not apply to GTK4.